### PR TITLE
Specify parent group

### DIFF
--- a/transpose-mark.el
+++ b/transpose-mark.el
@@ -37,7 +37,8 @@
 
 (defgroup transpose-mark nil
   "Transpose Mark group."
-  :prefix "transpose-mark-")
+  :prefix "transpose-mark-"
+  :group 'editing)
 
 (defface transpose-mark-region-set-face
   '((t :background "#7700ff" :foreground "#ffffff"))


### PR DESCRIPTION
This is useful for `customize`.

And not specifying parent group causes byte-compile warning.
I got following warning with original code.

```
transpose-mark.el:38:1:Warning: defgroup for `transpose-mark' fails to specify
    containing group
```
